### PR TITLE
Add quiz flow with Groq API integration

### DIFF
--- a/MoodProyect.Tests/GroqServiceTests.cs
+++ b/MoodProyect.Tests/GroqServiceTests.cs
@@ -1,0 +1,17 @@
+using MoodProyect.Models;
+using MoodProyect.Services;
+using Xunit;
+
+namespace MoodProyect.Tests;
+
+public class GroqServiceTests
+{
+    [Fact]
+    public async Task ReturnsFallbackWithoutApiKey()
+    {
+        Environment.SetEnvironmentVariable("GROQ_API_KEY", null);
+        var service = new GroqService(new HttpClient());
+        var result = await service.GetAdviceAsync(new QuizSession());
+        Assert.Contains("API key", result.Advice);
+    }
+}

--- a/MoodProyect.Tests/MoodProyect.Tests.csproj
+++ b/MoodProyect.Tests/MoodProyect.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../MoodProyect/MoodProyect.csproj" />
+  </ItemGroup>
+</Project>

--- a/MoodProyect.Tests/QuestionServiceTests.cs
+++ b/MoodProyect.Tests/QuestionServiceTests.cs
@@ -1,0 +1,15 @@
+using Xunit;
+using MoodProyect.Services;
+
+namespace MoodProyect.Tests;
+
+public class QuestionServiceTests
+{
+    [Fact]
+    public async Task ReturnsFiveQuestions()
+    {
+        var service = new QuestionService();
+        var questions = await service.GetQuestionsAsync();
+        Assert.Equal(5, questions.Count);
+    }
+}

--- a/MoodProyect.sln
+++ b/MoodProyect.sln
@@ -5,12 +5,18 @@ VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MoodProyect", "MoodProyect\MoodProyect.csproj", "{B95E0314-BE7A-49EC-B888-79F22A9ADA70}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MoodProyect.Tests", "MoodProyect.Tests\MoodProyect.Tests.csproj", "{D2F8E273-1234-4E88-9F3E-A1B2C3D4E5F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {D2F8E273-1234-4E88-9F3E-A1B2C3D4E5F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {D2F8E273-1234-4E88-9F3E-A1B2C3D4E5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {D2F8E273-1234-4E88-9F3E-A1B2C3D4E5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {D2F8E273-1234-4E88-9F3E-A1B2C3D4E5F6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B95E0314-BE7A-49EC-B888-79F22A9ADA70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B95E0314-BE7A-49EC-B888-79F22A9ADA70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B95E0314-BE7A-49EC-B888-79F22A9ADA70}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/MoodProyect/App.xaml
+++ b/MoodProyect/App.xaml
@@ -8,6 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Theme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/MoodProyect/AppShell.xaml
+++ b/MoodProyect/AppShell.xaml
@@ -3,13 +3,6 @@
     x:Class="MoodProyect.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MoodProyect"
-    Shell.FlyoutBehavior="Flyout"
-    Title="MoodProyect">
-
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
-
+    xmlns:views="clr-namespace:MoodProyect.Views">
+    <ShellContent Route="welcome" ContentTemplate="{DataTemplate views:WelcomePage}" />
 </Shell>

--- a/MoodProyect/AppShell.xaml.cs
+++ b/MoodProyect/AppShell.xaml.cs
@@ -1,10 +1,12 @@
-﻿namespace MoodProyect
+namespace MoodProyect
 {
     public partial class AppShell : Shell
     {
         public AppShell()
         {
             InitializeComponent();
+            Routing.RegisterRoute("quiz", typeof(Views.QuizPage));
+            Routing.RegisterRoute("result", typeof(Views.ResultPage));
         }
     }
 }

--- a/MoodProyect/Converters/BoolInverseConverter.cs
+++ b/MoodProyect/Converters/BoolInverseConverter.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+using System.Globalization;
+
+namespace MoodProyect.Converters;
+
+public class BoolInverseConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b ? !b : value;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is bool b ? !b : value;
+}

--- a/MoodProyect/MauiProgram.cs
+++ b/MoodProyect/MauiProgram.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+using MoodProyect.Services;
+using MoodProyect.ViewModels;
+using MoodProyect.Views;
 
 namespace MoodProyect
 {
@@ -15,8 +18,19 @@ namespace MoodProyect
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
 
+            builder.Services.AddSingleton<IQuestionService, QuestionService>();
+            builder.Services.AddHttpClient<IGroqService, GroqService>();
+
+            builder.Services.AddTransient<WelcomeViewModel>();
+            builder.Services.AddTransient<QuizViewModel>();
+            builder.Services.AddTransient<ResultViewModel>();
+
+            builder.Services.AddTransient<WelcomePage>();
+            builder.Services.AddTransient<QuizPage>();
+            builder.Services.AddTransient<ResultPage>();
+
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/MoodProyect/Models/Choice.cs
+++ b/MoodProyect/Models/Choice.cs
@@ -1,0 +1,7 @@
+namespace MoodProyect.Models;
+
+public class Choice
+{
+    public string Text { get; set; } = string.Empty;
+    public int Value { get; set; }
+}

--- a/MoodProyect/Models/GroqResult.cs
+++ b/MoodProyect/Models/GroqResult.cs
@@ -1,0 +1,3 @@
+namespace MoodProyect.Models;
+
+public record GroqResult(string Advice, string ClosingPhrase);

--- a/MoodProyect/Models/Question.cs
+++ b/MoodProyect/Models/Question.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace MoodProyect.Models;
+
+public class Question
+{
+    public string Id { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+    public bool IsOpen { get; set; }
+    public IReadOnlyList<Choice>? Choices { get; set; }
+    public string? Answer { get; set; }
+}

--- a/MoodProyect/Models/QuizSession.cs
+++ b/MoodProyect/Models/QuizSession.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace MoodProyect.Models;
+
+public class QuizSession
+{
+    public Dictionary<string, string> Answers { get; set; } = new();
+}

--- a/MoodProyect/MoodProyect.csproj
+++ b/MoodProyect/MoodProyect.csproj
@@ -62,6 +62,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+                <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/MoodProyect/Resources/Styles/Theme.xaml
+++ b/MoodProyect/Resources/Styles/Theme.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    <Style TargetType="ContentPage">
+        <Setter Property="BackgroundColor" Value="White" />
+        <Setter Property="Padding" Value="20" />
+    </Style>
+    <Style TargetType="Label">
+        <Setter Property="TextColor" Value="Black" />
+    </Style>
+    <Style TargetType="Button">
+        <Setter Property="BackgroundColor" Value="#512BD4" />
+        <Setter Property="TextColor" Value="White" />
+    </Style>
+</ResourceDictionary>

--- a/MoodProyect/Services/GroqService.cs
+++ b/MoodProyect/Services/GroqService.cs
@@ -1,0 +1,71 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using MoodProyect.Models;
+
+namespace MoodProyect.Services;
+
+public class GroqService : IGroqService
+{
+    private readonly HttpClient _httpClient;
+
+    public GroqService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<GroqResult> GetAdviceAsync(QuizSession session)
+    {
+        var apiKey = Environment.GetEnvironmentVariable("GROQ_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return new GroqResult("No hay API key configurada.", "Configura GROQ_API_KEY.");
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://api.groq.com/openai/v1/chat/completions");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var payload = new
+        {
+            model = "llama-3.1-70b-versatile",
+            messages = new object[]
+            {
+                new { role = "system", content = "Coach breve en español, máximo 120 palabras, incluye un ejercicio <=3 pasos, sin diagnóstico médico." },
+                new { role = "user", content = BuildUserPrompt(session) }
+            }
+        };
+
+        request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        try
+        {
+            var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            using var stream = await response.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            var content = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+            if (string.IsNullOrWhiteSpace(content))
+                return new GroqResult("No se obtuvo respuesta.", "Sigue adelante.");
+            var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            var advice = lines.FirstOrDefault() ?? content;
+            var closing = lines.Length > 1 ? lines.Last() : "Sigue adelante.";
+            return new GroqResult(advice, closing);
+        }
+        catch
+        {
+            return new GroqResult("No se pudo obtener consejo en este momento.", "Intenta nuevamente más tarde.");
+        }
+    }
+
+    private static string BuildUserPrompt(QuizSession session)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Respuestas del usuario:");
+        foreach (var item in session.Answers)
+        {
+            sb.AppendLine($"{item.Key}: {item.Value}");
+        }
+        sb.AppendLine("Proporciona un consejo breve y una frase de cierre motivadora.");
+        return sb.ToString();
+    }
+}

--- a/MoodProyect/Services/IGroqService.cs
+++ b/MoodProyect/Services/IGroqService.cs
@@ -1,0 +1,8 @@
+using MoodProyect.Models;
+
+namespace MoodProyect.Services;
+
+public interface IGroqService
+{
+    Task<GroqResult> GetAdviceAsync(QuizSession session);
+}

--- a/MoodProyect/Services/IQuestionService.cs
+++ b/MoodProyect/Services/IQuestionService.cs
@@ -1,0 +1,8 @@
+using MoodProyect.Models;
+
+namespace MoodProyect.Services;
+
+public interface IQuestionService
+{
+    Task<IReadOnlyList<Question>> GetQuestionsAsync();
+}

--- a/MoodProyect/Services/QuestionService.cs
+++ b/MoodProyect/Services/QuestionService.cs
@@ -1,0 +1,42 @@
+using MoodProyect.Models;
+
+namespace MoodProyect.Services;
+
+public class QuestionService : IQuestionService
+{
+    public Task<IReadOnlyList<Question>> GetQuestionsAsync()
+    {
+        var questions = new List<Question>
+        {
+            new()
+            {
+                Id = "1",
+                Text = "¿Cómo te sientes ahora?",
+                IsOpen = false,
+                Choices = new List<Choice>
+                {
+                    new() { Text = "Bien", Value = 2 },
+                    new() { Text = "Normal", Value = 1 },
+                    new() { Text = "Mal", Value = 0 }
+                }
+            },
+            new()
+            {
+                Id = "2",
+                Text = "¿Cómo ha sido tu nivel de energía hoy?",
+                IsOpen = false,
+                Choices = new List<Choice>
+                {
+                    new() { Text = "Alta", Value = 2 },
+                    new() { Text = "Media", Value = 1 },
+                    new() { Text = "Baja", Value = 0 }
+                }
+            },
+            new() { Id = "3", Text = "¿Qué te ha alegrado recientemente?", IsOpen = true },
+            new() { Id = "4", Text = "¿Qué te preocupa actualmente?", IsOpen = true },
+            new() { Id = "5", Text = "¿Qué objetivo te gustaría lograr mañana?", IsOpen = true }
+        };
+
+        return Task.FromResult<IReadOnlyList<Question>>(questions);
+    }
+}

--- a/MoodProyect/ViewModels/QuizViewModel.cs
+++ b/MoodProyect/ViewModels/QuizViewModel.cs
@@ -1,0 +1,100 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MoodProyect.Models;
+using MoodProyect.Services;
+using System.Collections.ObjectModel;
+
+namespace MoodProyect.ViewModels;
+
+public partial class QuizViewModel : ViewModelBase
+{
+    private readonly IQuestionService _questionService;
+    private readonly IGroqService _groqService;
+
+    public ObservableCollection<Question> Questions { get; } = new();
+
+    [ObservableProperty]
+    int currentIndex;
+
+    [ObservableProperty]
+    string? openAnswer;
+
+    [ObservableProperty]
+    Choice? selectedChoice;
+
+    public Question? CurrentQuestion => CurrentIndex >= 0 && CurrentIndex < Questions.Count ? Questions[CurrentIndex] : null;
+    public double Progress => Questions.Count == 0 ? 0 : (CurrentIndex + 1) / (double)Questions.Count;
+
+    public QuizViewModel(IQuestionService questionService, IGroqService groqService)
+    {
+        _questionService = questionService;
+        _groqService = groqService;
+    }
+
+    public override async void OnAppearing()
+    {
+        if (Questions.Count == 0)
+        {
+            var items = await _questionService.GetQuestionsAsync();
+            foreach (var q in items)
+                Questions.Add(q);
+            CurrentIndex = 0;
+        }
+    }
+
+    partial void OnCurrentIndexChanged(int value)
+    {
+        OpenAnswer = CurrentQuestion?.Answer;
+        SelectedChoice = null;
+    }
+
+    [RelayCommand]
+    void SelectChoice(Choice choice)
+    {
+        if (CurrentQuestion != null)
+        {
+            CurrentQuestion.Answer = choice.Text;
+            SelectedChoice = choice;
+        }
+    }
+
+    [RelayCommand]
+    void Next()
+    {
+        if (CurrentQuestion != null && CurrentQuestion.IsOpen)
+            CurrentQuestion.Answer = OpenAnswer;
+        if (CurrentIndex < Questions.Count - 1)
+            CurrentIndex++;
+    }
+
+    [RelayCommand]
+    void Prev()
+    {
+        if (CurrentQuestion != null && CurrentQuestion.IsOpen)
+            CurrentQuestion.Answer = OpenAnswer;
+        if (CurrentIndex > 0)
+            CurrentIndex--;
+    }
+
+    [RelayCommand]
+    async Task Finish()
+    {
+        if (CurrentQuestion != null && CurrentQuestion.IsOpen)
+            CurrentQuestion.Answer = OpenAnswer;
+
+        var session = new QuizSession();
+        foreach (var q in Questions)
+            session.Answers[q.Text] = q.Answer ?? string.Empty;
+
+        IsBusy = true;
+        var result = await _groqService.GetAdviceAsync(session);
+        IsBusy = false;
+
+        var parameters = new Dictionary<string, object>
+        {
+            { "Advice", result.Advice },
+            { "Closing", result.ClosingPhrase }
+        };
+        await Shell.Current.GoToAsync("result", parameters);
+    }
+}

--- a/MoodProyect/ViewModels/ResultViewModel.cs
+++ b/MoodProyect/ViewModels/ResultViewModel.cs
@@ -1,0 +1,25 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
+
+namespace MoodProyect.ViewModels;
+
+public partial class ResultViewModel : ViewModelBase, IQueryAttributable
+{
+    [ObservableProperty]
+    string advice = string.Empty;
+
+    [ObservableProperty]
+    string closingPhrase = string.Empty;
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("Advice", out var a))
+            Advice = a?.ToString() ?? string.Empty;
+        if (query.TryGetValue("Closing", out var c))
+            ClosingPhrase = c?.ToString() ?? string.Empty;
+    }
+
+    [RelayCommand]
+    Task Retry() => Shell.Current.GoToAsync("//welcome");
+}

--- a/MoodProyect/ViewModels/ViewModelBase.cs
+++ b/MoodProyect/ViewModels/ViewModelBase.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace MoodProyect.ViewModels;
+
+public partial class ViewModelBase : ObservableObject
+{
+    [ObservableProperty]
+    bool isBusy;
+
+    public virtual void OnAppearing() { }
+    public virtual void OnDisappearing() { }
+}

--- a/MoodProyect/ViewModels/WelcomeViewModel.cs
+++ b/MoodProyect/ViewModels/WelcomeViewModel.cs
@@ -1,0 +1,9 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace MoodProyect.ViewModels;
+
+public partial class WelcomeViewModel : ViewModelBase
+{
+    [RelayCommand]
+    private Task Start() => Shell.Current.GoToAsync("quiz");
+}

--- a/MoodProyect/Views/QuizPage.xaml
+++ b/MoodProyect/Views/QuizPage.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:conv="clr-namespace:MoodProyect.Converters"
+             x:Class="MoodProyect.Views.QuizPage"
+             x:Name="quizPage">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <conv:BoolInverseConverter x:Key="BoolInverseConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <VerticalStackLayout Padding="20" Spacing="20">
+        <ProgressBar Progress="{Binding Progress}" />
+        <Label Text="{Binding CurrentQuestion.Text}" FontSize="18" />
+        <StackLayout IsVisible="{Binding CurrentQuestion.IsOpen, Converter={StaticResource BoolInverseConverter}}"
+                     BindableLayout.ItemsSource="{Binding CurrentQuestion.Choices}">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <RadioButton Content="{Binding Text}"
+                                 GroupName="choices"
+                                 Command="{Binding BindingContext.SelectChoiceCommand, Source={x:Reference quizPage}}"
+                                 CommandParameter="{Binding .}" />
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </StackLayout>
+        <Entry IsVisible="{Binding CurrentQuestion.IsOpen}"
+               Text="{Binding OpenAnswer}" Placeholder="Escribe tu respuesta" />
+        <ActivityIndicator IsVisible="{Binding IsBusy}" IsRunning="{Binding IsBusy}" />
+        <HorizontalStackLayout>
+            <Button Text="Anterior" Command="{Binding PrevCommand}" />
+            <Button Text="Siguiente" Command="{Binding NextCommand}" />
+            <Button Text="Finalizar" Command="{Binding FinishCommand}" />
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
+</ContentPage>

--- a/MoodProyect/Views/QuizPage.xaml.cs
+++ b/MoodProyect/Views/QuizPage.xaml.cs
@@ -1,0 +1,19 @@
+using MoodProyect.ViewModels;
+
+namespace MoodProyect.Views;
+
+public partial class QuizPage : ContentPage
+{
+    public QuizPage(QuizViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is ViewModels.ViewModelBase vm)
+            vm.OnAppearing();
+    }
+}

--- a/MoodProyect/Views/ResultPage.xaml
+++ b/MoodProyect/Views/ResultPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MoodProyect.Views.ResultPage">
+    <VerticalStackLayout Padding="20" Spacing="20">
+        <Label Text="{Binding Advice}" FontSize="18" />
+        <Label Text="{Binding ClosingPhrase}" FontAttributes="Italic" />
+        <Button Text="Intentar de nuevo" Command="{Binding RetryCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/MoodProyect/Views/ResultPage.xaml.cs
+++ b/MoodProyect/Views/ResultPage.xaml.cs
@@ -1,0 +1,12 @@
+using MoodProyect.ViewModels;
+
+namespace MoodProyect.Views;
+
+public partial class ResultPage : ContentPage
+{
+    public ResultPage(ResultViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}

--- a/MoodProyect/Views/WelcomePage.xaml
+++ b/MoodProyect/Views/WelcomePage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MoodProyect.Views.WelcomePage">
+    <VerticalStackLayout Padding="20" Spacing="20">
+        <Label Text="Bienvenido a MoodCoach" FontSize="24" HorizontalOptions="Center" />
+        <Button Text="Empezar" Command="{Binding StartCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/MoodProyect/Views/WelcomePage.xaml.cs
+++ b/MoodProyect/Views/WelcomePage.xaml.cs
@@ -1,0 +1,12 @@
+using MoodProyect.ViewModels;
+
+namespace MoodProyect.Views;
+
+public partial class WelcomePage : ContentPage
+{
+    public WelcomePage(WelcomeViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# MoodCoach
+
+Aplicación de ejemplo construida con .NET 9 MAUI siguiendo MVVM.
+
+## Requisitos
+- SDK .NET 9
+- Workloads MAUI
+
+## Ejecutar
+```bash
+ dotnet workload install maui
+ dotnet build
+ dotnet maui run
+```
+
+## Variables de entorno
+Configura la clave de Groq antes de ejecutar:
+```bash
+export GROQ_API_KEY="<tu_clave>"
+```
+
+## Estructura
+- `MoodProyect/` código principal
+- `MoodProyect.Tests/` pruebas xUnit
+
+Las preguntas del cuestionario están definidas en `QuestionService` y la llamada a Groq se realiza en `GroqService`.


### PR DESCRIPTION
## Summary
- Add models, services, and view models for a 5-question quiz
- Call Groq API to fetch advice and closing phrase
- Create MVVM pages and basic styling plus xUnit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978e4937ac8328a61d7d1b09e52811